### PR TITLE
Save aquired locks in transaction context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ For this purpose (similarly to mnesia transactions) there is an internal context
 storage, which stores all the write operations until transaction is committed
 or rolled back.
 
-Each operation have to aquire a lock, which is done by calling the special lock
+Each operation have to acquire a lock, which is done by calling the special lock
 process. More on locks [here](./LOCK_PROCESS.md)
 
 Reads get data from both context and the mnesia database. All reads from mnesia
@@ -175,8 +175,8 @@ When transaction is restarted - all its locks and transaction context is cleared
 but transaction ID stays registered with the lock process.
 
 **Behaviour differences with mnesia**
-Because locks are aquired cluster-wide and not on specific nodes, global locks
-aquired with a `{global, LockTerm :: term(), Nodes :: [node()]}` lock item will
+Because locks are acquired cluster-wide and not on specific nodes, global locks
+acquired with a `{global, LockTerm :: term(), Nodes :: [node()]}` lock item will
 not scope on nodes. It will lock all nodes on `LockTerm`.
 
 ### Snapshotting and log replay

--- a/src/mnevis.erl
+++ b/src/mnevis.erl
@@ -705,7 +705,7 @@ cleanup_all_unlock_messages() ->
     end.
 
 with_lock(Context, LockItem, LockKind, Fun) ->
-    case aquire_lock(Context, LockItem, LockKind, lock) of
+    case acquire_lock(Context, LockItem, LockKind, lock) of
         {ok, _}      -> Fun();
         {error, Err} -> mnesia:abort(Err)
     end.
@@ -735,10 +735,10 @@ with_lock_and_version(Context, LockItem, LockKind, Fun) ->
         end
     end).
 
-aquire_lock(Context, LockItem, LockKind, Method) ->
-    case do_aquire_lock(Context, LockItem, LockKind, Method) of
+acquire_lock(Context, LockItem, LockKind, Method) ->
+    case do_acquire_lock(Context, LockItem, LockKind, Method) of
         {ok, Response, Context1} ->
-            Context2 = mnevis_context:set_lock_aquired(LockItem, LockKind, Context1),
+            Context2 = mnevis_context:set_lock_acquired(LockItem, LockKind, Context1),
             update_transaction_context(Context2),
             {ok, Response};
         {error, Err, Context1} ->
@@ -746,18 +746,18 @@ aquire_lock(Context, LockItem, LockKind, Method) ->
             {error, Err}
     end.
 
-do_aquire_lock(Context, LockItem, LockKind, Method) ->
+do_acquire_lock(Context, LockItem, LockKind, Method) ->
     case mnevis_context:has_transaction(Context) of
         true ->
-            do_aquire_lock_with_existing_transaction(Context, LockItem, LockKind, Method);
+            do_acquire_lock_with_existing_transaction(Context, LockItem, LockKind, Method);
         false ->
-            do_aquire_lock_with_new_transaction(Context, LockItem, LockKind, Method, ?AQUIRE_LOCK_ATTEMPTS)
+            do_acquire_lock_with_new_transaction(Context, LockItem, LockKind, Method, ?AQUIRE_LOCK_ATTEMPTS)
     end.
 
-do_aquire_lock_with_existing_transaction(Context, LockItem, LockKind, Method) ->
+do_acquire_lock_with_existing_transaction(Context, LockItem, LockKind, Method) ->
     Tid = mnevis_context:transaction_id(Context),
     Locks = mnevis_context:locks(Context),
-    case lock_already_aquired(LockItem, LockKind, Locks) of
+    case lock_already_acquired(LockItem, LockKind, Locks) of
         true ->
             {ok, ok, Context};
         false ->
@@ -773,16 +773,16 @@ do_aquire_lock_with_existing_transaction(Context, LockItem, LockKind, Method) ->
     end.
 
 %% TODO: maybe merge that with mnevis_lock
-lock_already_aquired({table, _} = LockItem, LockKind, Locks) ->
-    lock_already_aquired_1(LockItem, LockKind, Locks);
-lock_already_aquired({Tab, Key}, LockKind, Locks) ->
-    lock_already_aquired_1({table, Tab}, LockKind, Locks)
+lock_already_acquired({table, _} = LockItem, LockKind, Locks) ->
+    lock_already_acquired_1(LockItem, LockKind, Locks);
+lock_already_acquired({Tab, Key}, LockKind, Locks) ->
+    lock_already_acquired_1({table, Tab}, LockKind, Locks)
     orelse
-    lock_already_aquired_1({Tab, Key}, LockKind, Locks);
-lock_already_aquired({global, _, _} = LockItem, LockKind, Locks) ->
-    lock_already_aquired_1(LockItem, LockKind, Locks).
+    lock_already_acquired_1({Tab, Key}, LockKind, Locks);
+lock_already_acquired({global, _, _} = LockItem, LockKind, Locks) ->
+    lock_already_acquired_1(LockItem, LockKind, Locks).
 
-lock_already_aquired_1(LockItem, LockKind, Locks) ->
+lock_already_acquired_1(LockItem, LockKind, Locks) ->
     case {LockKind, maps:get(LockItem, Locks, none)} of
         {read,  read}  -> true;
         {read,  write} -> true;
@@ -793,9 +793,9 @@ lock_already_aquired_1(LockItem, LockKind, Locks) ->
         {_, none}      -> false
     end.
 
-do_aquire_lock_with_new_transaction(_Context, _LockItem, _LockKind, _Method, 0) ->
-    mnesia:abort({unable_to_aquire_lock, no_promoted_lock_processes});
-do_aquire_lock_with_new_transaction(Context, LockItem, LockKind, Method, Attempts) ->
+do_acquire_lock_with_new_transaction(_Context, _LockItem, _LockKind, _Method, 0) ->
+    mnesia:abort({unable_to_acquire_lock, no_promoted_lock_processes});
+do_acquire_lock_with_new_transaction(Context, LockItem, LockKind, Method, Attempts) ->
     ok = mnevis_context:assert_no_transaction(Context),
     %% TODO: monitor the lock process to make sure there is no disconnect.
     %% If there is a disconnect - the locker process will clean up the locks,
@@ -820,7 +820,7 @@ do_aquire_lock_with_new_transaction(Context, LockItem, LockKind, Method, Attempt
             {error, locked_nowait, NewContext};
         {error, is_not_leader} ->
             %% TODO: notify when leader or timeout
-            do_aquire_lock_with_new_transaction(Context, LockItem, LockKind, Method, Attempts - 1);
+            do_acquire_lock_with_new_transaction(Context, LockItem, LockKind, Method, Attempts - 1);
         {error, Error} ->
             mnesia:abort(Error)
     end.

--- a/src/mnevis_context.erl
+++ b/src/mnevis_context.erl
@@ -18,6 +18,8 @@
          transaction/1,
          transaction_id/1,
          locker/1,
+         locks/1,
+         set_lock_aquired/3,
 
          has_transaction/1,
          assert_transaction/1,
@@ -110,8 +112,11 @@
 -type transaction() :: {mnevis_lock:transaction_id(),
                         mnevis_lock_proc:locker()}.
 
+-type locks() :: #{term() => lock_kind()}.
+
 -record(context, {
     transaction = undefined :: transaction() | undefined,
+    locks = #{} :: locks(),
     delete = #{} :: #{tabkey() => delete_item()},
     delete_object = #{} :: #{tabkey() => item()},
     write_set = #{} :: #{tabkey() => item()},
@@ -144,6 +149,18 @@ transaction_id(#context{transaction = {Tid, _}}) -> Tid.
 -spec locker(context()) -> mnevis_lock_proc:locker().
 locker(#context{transaction = {_, Locker}}) -> Locker.
 
+-spec locks(context()) -> locks().
+locks(#context{locks = Locks}) -> Locks.
+
+-spec set_lock_aquired(term(), lock_kind(), context()) -> context().
+set_lock_aquired(LockItem, LockKind, #context{locks = Locks} = Context) ->
+    Locks1 = case {LockKind, maps:get(LockItem, Locks, none)} of
+        {_, none}     -> maps:put(LockItem, LockKind, Locks);
+        {write, read} -> maps:put(LockItem, LockKind, Locks);
+        _ -> Locks
+    end,
+    Context#context{locks = Locks1}.
+
 -spec has_transaction(context()) -> boolean().
 has_transaction(#context{transaction = undefined}) -> false;
 has_transaction(#context{transaction = {_, {_, _}}}) -> true.
@@ -174,7 +191,7 @@ assert_no_transaction(Context) ->
 -spec set_transaction(transaction(), context()) -> context().
 set_transaction(Transaction, Context) ->
     assert_no_transaction(Context),
-    Context#context{transaction = Transaction}.
+    Context#context{transaction = Transaction, locks = #{}}.
 
 %% Remove everything except transaction.
 -spec cleanup_changes(context()) -> context().

--- a/src/mnevis_context.erl
+++ b/src/mnevis_context.erl
@@ -19,7 +19,7 @@
          transaction_id/1,
          locker/1,
          locks/1,
-         set_lock_aquired/3,
+         set_lock_acquired/3,
 
          has_transaction/1,
          assert_transaction/1,
@@ -152,8 +152,8 @@ locker(#context{transaction = {_, Locker}}) -> Locker.
 -spec locks(context()) -> locks().
 locks(#context{locks = Locks}) -> Locks.
 
--spec set_lock_aquired(term(), lock_kind(), context()) -> context().
-set_lock_aquired(LockItem, LockKind, #context{locks = Locks} = Context) ->
+-spec set_lock_acquired(term(), lock_kind(), context()) -> context().
+set_lock_acquired(LockItem, LockKind, #context{locks = Locks} = Context) ->
     Locks1 = case {LockKind, maps:get(LockItem, Locks, none)} of
         {_, none}     -> maps:put(LockItem, LockKind, Locks);
         {write, read} -> maps:put(LockItem, LockKind, Locks);


### PR DESCRIPTION
Cache aquired locks in the transaction process.
Do not call the locker process if the lock is already aquired.

If there is a write lock aquired - do not call locker to check a read lock.

If there is a table lock aquired - do not call locker to check an item lock.

To test:

This gist: https://gist.github.com/hairyhum/523e07932d1f82004138fa7bb1c76290 contains a module, which can be used to test bindings and queues performance.

For example to measure time to declare 1000 bindings concurrently:
```
timer:tc(fun() -> schema_test:add_bindings(1, 1000, <<"1">>), ok end).
```

For example to measure time to declare 10 bindings per process in 100 concurrent processes:
```
timer:tc(fun() -> schema_test:add_bindings(10, 100, <<"1">>), ok end).
```

To test bindings, there should be queue "foo" and exchange "foo" declared in the broker. Without those resources it will run in "read only" mode, which is also a reasonable test.

Functions in the test may be run multiple time to account for version table buildup.