### PR TITLE
Inconsistent error handling

### DIFF
--- a/src/mnevis_machine.erl
+++ b/src/mnevis_machine.erl
@@ -415,30 +415,6 @@ consistent_error(Reason) when is_tuple(Reason), size(Reason) > 0 ->
 %% Any other error reason is considered inconsistent.
 consistent_error(_Reason) -> false.
 
-
-
-% TODO LRB
-% -spec catch_abort(fun(() -> reply(R, E))) -> reply(R, E | {aborted, term()}).
-% catch_abort(Fun) ->
-%     try
-%         Fun()
-%     catch exit:{aborted, Reason} ->
-%         {error, {aborted, Reason}}
-%     end.
-%
-% -spec with_transaction(transaction(), state(),
-%                        fun(() -> reply(T, E))) -> apply_result(T, E).
-% with_transaction(Transaction, State, Fun) ->
-%     with_valid_locker(Transaction, State,
-%         fun() ->
-%             case transaction_recorded_as_committed(Transaction) of
-%                 %% This is a log replay and the transaction is already committed.
-%                 %% Result will not be received by any client.
-%                 true  -> {State, {error, {transaction_committed, Transaction}}, []};
-%                 false -> {State, Fun(), []}
-%             end
-%         end).
-
 %% ==============================
 
 -ifdef(TEST).


### PR DESCRIPTION
Some errors may be based on the mnesia state,
others may be specific to the node.

We want all operations to evaluate the same result on all
nodes and node specifoc failures should crash the ra node and let it recover.

There is a danger that some commands will crash nodes all the time,
but technically this should not happen.

Requires more testing for potential failures.