### PR TITLE
Handle transaction process failures consistently.

### DIFF
--- a/src/mnevis.erl
+++ b/src/mnevis.erl
@@ -288,10 +288,7 @@ commit_transaction() ->
                     case {Writes, Deletes, DeletesObject} of
                         {[], [], []} ->
                             %% Read-only commits
-                            case read_only_commit(Context) of
-                                ok -> ok;
-                                {error, Err} -> mnesia:abort(Err)
-                            end;
+                            read_only_commit(Context);
                         _ ->
                             {ok, Result, _} =
                                 execute_command_with_retry(Context, commit,

--- a/src/mnevis_context.erl
+++ b/src/mnevis_context.erl
@@ -93,7 +93,8 @@
 
 -type read_op() :: dirty_all_keys | dirty_first | dirty_last |
                    dirty_index_match_object | dirty_index_read  |
-                   dirty_match_object | dirty_read.
+                   dirty_match_object | dirty_read | dirty_prev |
+                   dirty_next.
 
 -type read_spec() :: {read_op(), [table() | key()]}.
 -type version() :: non_neg_integer().

--- a/src/mnevis_lock.eunit
+++ b/src/mnevis_lock.eunit
@@ -310,15 +310,11 @@ cleanup_transaction_test() ->
     after 1000 -> error({unlock_message_lost, notified_is_not_received})
     end.
 
-monitor_down_cleanup_test() ->
+monitor_down_test() ->
     State = init(0),
     Source = self(),
     Self = self(),
-    Source1 = spawn(fun() ->
-        receive {mnevis_unlock, _} ->
-            Self ! notified
-        end
-    end),
+    Source1 = spawn(fun() -> ok end),
 
     flush_notified(),
 
@@ -331,25 +327,16 @@ monitor_down_cleanup_test() ->
 
     {{error, {locked, Tid1}}, State4} = lock(Tid1, Source1, LockItem, write, State3),
 
-    State5 = monitor_down(ref, Source, reason, State4),
+    {Tid, State5} = monitor_down(ref, Source, reason, State4),
 
     #state{
-        transactions = #{Source1 := Tid1},
-        read_locks = #{},
-        reverse_read_locks = #{},
-        write_locks = #{},
-        reverse_write_locks = #{},
-        monitors = Monitors,
-        transaction_locks = TransLocks
+        monitors = Monitors
     } = State5,
 
-    [] = simple_dgraph:out_neighbours(TransLocks, Tid1),
-    [] = simple_dgraph:in_neighbours(TransLocks, Tid1),
-    [Source1] = maps:keys(Monitors),
+    %% monitor_down only changes monitors
+    State5 = State4#state{monitors = Monitors},
 
-    receive notified -> ok
-    after 1000 -> error({unlock_message_lost, notified_is_not_received})
-    end.
+    [Source1] = maps:keys(Monitors).
 
 monitor_down_unknown_test() ->
     State = init(0),
@@ -369,7 +356,7 @@ monitor_down_unknown_test() ->
 
     {{error, {locked, Tid1}}, State4} = lock(Tid1, Source1, LockItem, write, State3),
 
-    State4 = monitor_down(ref, spawn(fun() -> ok end), reason, State4).
+    {none, State4} = monitor_down(ref, spawn(fun() -> ok end), reason, State4).
 
 
 flush_notified() ->

--- a/src/mnevis_lock_proc.erl
+++ b/src/mnevis_lock_proc.erl
@@ -142,7 +142,7 @@ get_current_ra_locker(CurrentLocker) ->
     mnevis_lock:lock_result() |
     {ok, mnevis_lock:transaction_id(), term()} |
     {error, locker_not_running} |
-    {error, is_not_leader}.
+    {error, locker_timeout}.
 try_lock_call({Term, Pid}, LockRequest) ->
     try
         gen_statem:call(Pid, {LockRequest, Term}, ?LOCKER_TIMEOUT)

--- a/src/mnevis_lock_proc.erl
+++ b/src/mnevis_lock_proc.erl
@@ -191,7 +191,7 @@ candidate(info, {ra_event, Leader, Event}, State) ->
 candidate(timeout, _, State = #state{term = Term, leader = Leader}) ->
     Correlation = notify_up(Term, Leader),
     {keep_state, State#state{correlation = Correlation}, [1000]};
-candidate({call, From}, {lock, _Tid, _Source, _LockItem, _LockKind}, State) ->
+candidate({call, _From}, {lock, _Tid, _Source, _LockItem, _LockKind}, State) ->
     %% Delay until we're leader
     {keep_state, State, [postpone]};
 candidate(cast, _, State) ->

--- a/src/mnevis_machine.erl
+++ b/src/mnevis_machine.erl
@@ -12,6 +12,7 @@
 -export([check_locker/2]).
 -export([safe_table_info/3]).
 -export([get_item_version/2]).
+-export([compare_versions/2]).
 
 -record(state, {
     locker_status = down,
@@ -51,6 +52,11 @@ check_locker({LockerTerm, _LockerPid}, #state{locker = {CurrentLockerTerm, _}}) 
         CurrentLockerTerm -> ok;
         _                 -> {error, wrong_locker_term}
     end.
+
+-spec compare_versions([mnevis_context:read_version()], term()) ->
+    ok | {version_mismatch, [mnevis_context:read_version()]}.
+compare_versions(Versions, _State) ->
+    mnevis_read:compare_versions(Versions).
 
 -spec safe_table_info(mnevis:table(), term(), state()) ->
     {ok, term()} | {error, {no_exists, mnevis:table()}}.

--- a/src/mnevis_machine.erl
+++ b/src/mnevis_machine.erl
@@ -210,7 +210,7 @@ apply(_Meta, {locker_up, {Term, Pid} = Locker},
         %% Duplicate?
         %% TODO: do we need duplicate monitor? is it safe?
         {CurrentLockerTerm, CurrentLockerPid} ->
-            {State, confirm, [{monitor, process, Pid}]};
+            {State#state{locker_status = up}, confirm, [{monitor, process, Pid}]};
         {HigherTerm, _} when HigherTerm > CurrentLockerTerm ->
             ok = mnevis_lock_proc:update_locker_cache(Locker),
             MaybeStopEffects = case Pid of

--- a/src/mnevis_machine.eunit
+++ b/src/mnevis_machine.eunit
@@ -77,10 +77,10 @@ commit_write_test() ->
 
 down_creates_new_locker_test() ->
     InitState = init_state(),
-    #state{locker = {_, LockerPid} = Locker} = InitState,
+    #state{locker = {LockerTerm, LockerPid}} = InitState,
     NewState = InitState#state{locker_status = down},
     {NewState, ok,
-     [{mod_call, mnevis_lock_proc, start_new_locker, [Locker]}]} =
+     [{mod_call, mnevis_lock_proc, start_new_locker, [LockerTerm]}]} =
        mnevis_machine:apply(none, {down, LockerPid, reason}, InitState).
 
 down_ignores_not_current_locker_test() ->
@@ -107,7 +107,7 @@ locker_up_registers_same_locker_test() ->
 locker_up_registers_higher_term_test() ->
     InitState = init_state(),
     mnevis_lock_proc:create_locker_cache(),
-    #state{locker = {Term, _}} = InitState,
+    #state{locker = {Term, LockerPid}} = InitState,
     LockerDownState = InitState#state{locker_status = down},
 
     NewPid = spawn(fun() -> ok end),
@@ -117,11 +117,25 @@ locker_up_registers_higher_term_test() ->
     NewState = InitState#state{locker = NewLocker,
                                locker_status = up},
 
-    {NewState, confirm, [{monitor, process, NewPid}]} =
+    {NewState, confirm, [{monitor, process, NewPid},
+                         {mod_call, mnevis_lock_proc, stop, [LockerPid]}]} =
         mnevis_machine:apply(none, {locker_up, NewLocker}, InitState),
 
-    {NewState, confirm, [{monitor, process, NewPid}]} =
+    {NewState, confirm, [{monitor, process, NewPid},
+                         {mod_call, mnevis_lock_proc, stop, [LockerPid]}]} =
         mnevis_machine:apply(none, {locker_up, NewLocker}, LockerDownState).
+
+locker_up_rejects_same_term_different_pid_test() ->
+    InitState = init_state(),
+    mnevis_lock_proc:create_locker_cache(),
+    #state{locker = {Term, Pid}} = InitState,
+    NotSamePid = spawn(fun() -> ok end),
+    LockerDownState = InitState#state{locker_status = down},
+    {InitState, reject, []} =
+        mnevis_machine:apply(none, {locker_up, {Term, NotSamePid}}, InitState),
+
+    {LockerDownState, reject, []} =
+        mnevis_machine:apply(none, {locker_up, {Term, NotSamePid}}, LockerDownState).
 
 locker_up_rejects_lower_term_test() ->
     InitState = init_state(),
@@ -166,10 +180,10 @@ which_locker_old_returns_current_test() ->
 
 which_locker_current_returns_error_and_effect_test() ->
     InitState = init_state(),
-    #state{locker = Locker} = InitState,
+    #state{locker = {LockerTerm, _} = Locker} = InitState,
 
-    {InitState, {error, locker_up_to_date},
-     [{mod_call, mnevis_lock_proc, start_new_locker, [Locker]}]} =
+    {InitState, {error, waiting_for_new_locker},
+     [{mod_call, mnevis_lock_proc, start_new_locker, [LockerTerm]}]} =
         mnevis_machine:apply(none, {which_locker, Locker}, InitState).
 
 which_locker_newer_error_test() ->

--- a/src/mnevis_read.erl
+++ b/src/mnevis_read.erl
@@ -1,6 +1,8 @@
 -module(mnevis_read).
 
 -export([create_versions_table/0]).
+-export([all_table_versions/0]).
+-export([compare_versions/1]).
 -export([get_version/1, update_version/1, init_version/2]).
 -export([local_read_query/1, local_read_query/2]).
 -export([wait_for_versions/1]).
@@ -12,6 +14,16 @@ create_versions_table() ->
         {aborted,{already_exists,versions}} -> ok;
         Other -> error({cannot_create_versions_table, Other})
     end.
+
+all_table_versions() ->
+    Tables = mnesia:system_info(tables),
+    lists:filtermap(fun(Tab) ->
+        case get_version(Tab) of
+            {ok, Version}      -> {true, {Tab, Version}};
+            {error, no_exists} -> false
+        end
+    end,
+    Tables).
 
 -spec get_version({mnevis:table(), term()} | mnevis:table()) ->
     {ok, mnevis_context:version()} | {error, no_exists}.

--- a/src/mnevis_read.erl
+++ b/src/mnevis_read.erl
@@ -13,7 +13,8 @@ create_versions_table() ->
         Other -> error({cannot_create_versions_table, Other})
     end.
 
--spec get_version(mnevis:table()) -> {ok, mnevis_context:version()} | {error, no_exists}.
+-spec get_version({mnevis:table(), term()} | mnevis:table()) ->
+    {ok, mnevis_context:version()} | {error, no_exists}.
 get_version(Tab) ->
     %% TODO: handle error
     MaybeVersion = ets:lookup(versions, Tab),
@@ -117,7 +118,7 @@ wait_for_versions(TargetVersions) ->
                 try
                     wait_for_mnesia_updates(VersionsToWait)
                 after
-                    mnesia:unsubscribe({table, versions, simple}),
+                    _ = mnesia:unsubscribe({table, versions, simple}),
                     flush_table_events()
                 end
             end),

--- a/src/mnevis_snapshot.erl
+++ b/src/mnevis_snapshot.erl
@@ -257,6 +257,8 @@ state_file(Dir) ->
     filename:join(Dir, "saved_state").
 
 restore_mnesia_backup(BackupFile) ->
+    %% TODO: test recovery. Does it make sense to restart mnesia instead?
+    %% Should we use schema_location = ram ?
     case mnesia:restore(BackupFile, [{default_op, recreate_tables}]) of
         {atomic, _}       -> ok;
         {aborted, Reason} -> {error, {aborted, Reason}}

--- a/test/transaction_SUITE.erl
+++ b/test/transaction_SUITE.erl
@@ -147,6 +147,7 @@ create_sample_tables() ->
     {atomic, ok} = mnevis:create_table(sample, [{type, set}, {index, [3]}]),
     {atomic, ok} = mnevis:create_table(sample_bag, [{type, bag}, {index, [3]}]),
     {atomic, ok} = mnevis:create_table(sample_ordered_set, [{type, ordered_set}, {index, [3]}]),
+    ok = mnevis:sync(),
     ok.
 
 delete_sample_tables() ->


### PR DESCRIPTION
Transaction processes are monitored by the locker process.
This means that transaction may be crashed from the
locker point of view, but still running.

This can cause races when a new transaction checks locks
after the down message, but commits before the "failed"
transaction commit.

This breaks the consistency guarantee.

To prevent that we may block the "failed" transaction from
committing. This can be done by locker process communicating
to the raft process and asking it to "blacklist" the transaction.

Blacklisted transactions will return an error on commit.

The locker process may clean up the "failed" transaction locks after
it gets a confirmation that the "blacklist" command was applied.
From that point the "failed" transaction cannot be committed and it's
safe to cleanup its locks.

"L" - the locker holds the transaction lock.
Other transactions cannot use the locked resource.
After DOWN message other transactions may aquire a lock on a resource already
owned by transaction 1.

Because of that there can be an inconsistency between transactions:
```
   tr1                     locker        machine
    |                        |              |
    |  Lock ok               |              |
    |----------------------> L1             |
    |                        L1             |
    |    DOWN                L1             |
    |----------------------> L1             |
    |                        |              |
    |         tr2            |              |
    |          |   Lock ok   |              |
    |          |------------>L2             |
    |          |             L2             |
    |          |     commit2 ok             |
    |          |--------------------------->|
    |   commit1 ok                          |
    |-------------------------------------->|
```

With transaction blacklisting:

```
   tr1                     locker        machine
    |                        |              |
    |  Lock ok               |              |
    |----------------------> L1             |
    |                        L1             |
    |    DOWN                L1             |
    |----------------------> L1             |
    |                        L1             |
    |                        L1 blacklist   |
    |         tr2            L1-----------> |
    |          |             L1             |
    |          | Lock wait   L1             |
    |          | ----------> L1 blacklisted |
    |          |             L1 <---------- |
    |          | retry lock  |              |
    |          |-----------> L2             |
    |          |             L2             |
    |          |             L2             |
    |          |     commit2 ok             |
    |          |--------------------------->|
    |   commit1 rejected (blacklisted)      |
    |-------------------------------------->|
```